### PR TITLE
Fix ytpromo time for borgs

### DIFF
--- a/orienteer/general/data/orienteer/services/ytpromo.py
+++ b/orienteer/general/data/orienteer/services/ytpromo.py
@@ -51,7 +51,7 @@ async def try_ytpromo(user_id: UUID, code: str, selected_department: str) -> tup
                 "JobScientist": 300,
             },
             "Синтетики": {
-                "Overall": 300,
+                "Overall": 900,
                 "JobBorg": 600,
             },
             "Сервисный отдел": {


### PR DESCRIPTION
**На сервере требуется 15 часов общего времени для открытия юнитов. Промокод с выбором отдела при выборе синтетов даже не откроет человеку юнитов, поэтому исправляю начисляемое время для синтетов**

Было раньше:
![изображение](https://github.com/user-attachments/assets/35a247ef-f7bf-4cf0-a4cb-b8098875c85f)

Стало:
![изображение](https://github.com/user-attachments/assets/8be3535f-61bf-4bcd-88c3-a891de27b53c)
