### PR TITLE
Lock poetry version at Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 COPY orienteer ./orienteer/
-RUN python -m pip install --upgrade pip && pip install poetry
+RUN python -m pip install --upgrade pip && pip install poetry==1.8.3
 RUN poetry config virtualenvs.create false && poetry install --no-dev --no-interaction --no-ansi


### PR DESCRIPTION
## Lock poetry version in Dockerfile

**Media**
before:
![before](https://github.com/user-attachments/assets/b3a81f1e-c97f-4e87-9f94-4f83f2503c78)

after:
![after](https://github.com/user-attachments/assets/73e4789e-bc01-48aa-8e74-c415b249fb7f)

**Checks**
1) On local docker container

**Changes**
1) Locked poetry version at Dockerfile

