### PR TITLE
Fix shop and server status

### DIFF
--- a/orienteer/bot/calls/info.py
+++ b/orienteer/bot/calls/info.py
@@ -23,7 +23,7 @@ from orienteer.general.utils.dtos import UserDTO
 
 class Status(AbstractCall):
     async def __call__(self) -> None:
-        server_data = await hub.find_server_data("ss14://amadis.orientacorp.ru:1313")
+        server_data = await hub.find_server_data("ss14://78.29.37.125:1212/")
 
         if server_data is None:
             await self.interaction.edit_original_message(

--- a/orienteer/general/data/orienteer/models/sponsors.py
+++ b/orienteer/general/data/orienteer/models/sponsors.py
@@ -20,7 +20,7 @@ class Sponsor(Base):
     allowed_markings = mapped_column(ARRAY(String), nullable=False, default=[])
     loadouts = mapped_column(ARRAY(String), nullable=False, default=[])
     open_all_roles = mapped_column(Boolean, nullable=False, default=False)
-    ghost_theme = mapped_column(String, nullable=True, default=False)
+    ghost_theme = mapped_column(String, nullable=True, default=None)
 
     sponsor_chat = mapped_column(Boolean, nullable=False, default=False)
 

--- a/orienteer/general/data/orienteer/repositories/sponsors.py
+++ b/orienteer/general/data/orienteer/repositories/sponsors.py
@@ -14,7 +14,8 @@ async def try_create_empty_sponsor(db_session: AsyncSession, user_id) -> Sponsor
         await db_session.execute(select(Sponsor).filter_by(user_id=user_id))
     ).fetchone()
     if sponsor is None:
-        sponsor = Sponsor(user_id)
+        sponsor = Sponsor()
+        sponsor.user_id = user_id
         db_session.add(sponsor)
         await db_session.commit()
         await db_session.refresh(sponsor)


### PR DESCRIPTION
### Problems:
1) **Server status allways "error"**
![изображение](https://github.com/user-attachments/assets/58b39c8d-d121-4d5c-8aec-ba0b3f98e9ab)

2) **Shop didn't work**
![изображение](https://github.com/user-attachments/assets/732b9d68-302d-4579-9050-e7352c04c9e9)

### Changes
**Shop:**
1) orienteer\general\data\orienteer\models\sponsors.py: "ghost_theme" is a string field, but its default was "False" (a bool). Strings can't be bools, so I changed it to None. 
2) orienteer\general\data\orienteer\repositories\sponsors.py: "Sponsor(user_id)" didn’t work as expected due to SQLAlchemy’s __init__ with MappedAsDataclass, so I switched to creating it with "Sponsor()" and setting "user_id" manually

**Status:**
1) orienteer\bot\calls\info.py:
Server address in JSON request to hub changed from "ss14://amadis.orientacorp.ru:1313" to "ss14://78.29.37.125:1212/" to match the new hub data.

### Checks
1) **Status**
![изображение](https://github.com/user-attachments/assets/d136c680-10a9-4221-bdda-b7c1854ff886)

2) **Shop**
 
![изображение](https://github.com/user-attachments/assets/81138c63-3b9f-44b6-ba31-b1c244b6bd23)
